### PR TITLE
There's an import missing

### DIFF
--- a/offlineimap/folder/Base.py
+++ b/offlineimap/folder/Base.py
@@ -31,8 +31,7 @@ class BaseFolder(object):
         :para name: Path & name of folder minus root or reference
         :para repository: Repository() in which the folder is.
         """
-        self.sync_this = True
-        """Should this folder be included in syncing?"""
+        self._sync_this = repository.should_sync_folder(name)
         self.ui = getglobalui()
         # Top level dir name is always ''
         self.name = name if not name == self.getsep() else ''
@@ -44,6 +43,20 @@ class BaseFolder(object):
         if self.visiblename == self.getsep():
             self.visiblename = ''
         self.config = repository.getconfig()
+
+    @property
+    def sync_this(self):
+        return self._sync_this
+
+    def sync_this_verbose(self):
+        if not self.sync_this:
+            locality = 'local' \
+                if self.repository == self.repository.account.localrepos \
+                else 'remote'
+            self.ui.debug(
+                '', "Not syncing filtered %s folder '%s'[%s]"
+                % (locality, self, self.repository))
+        return self.sync_this
 
     def getname(self):
         """Returns name"""

--- a/offlineimap/folder/Base.py
+++ b/offlineimap/folder/Base.py
@@ -181,7 +181,7 @@ class BaseFolder(object):
     def getmessageuidlist(self):
         """Gets a list of UIDs.
         You may have to call cachemessagelist() before calling this function!"""
-        return self.getmessagelist().keys()
+        return sorted(self.getmessagelist())
 
     def getmessagecount(self):
         """Gets the number of messages."""

--- a/offlineimap/folder/UIDMaps.py
+++ b/offlineimap/folder/UIDMaps.py
@@ -16,6 +16,7 @@
 #    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
 from threading import Lock
 from .IMAP import IMAPFolder
+from offlineimap.error import OfflineImapError
 import os.path
 
 class MappedIMAPFolder(IMAPFolder):

--- a/offlineimap/repository/Base.py
+++ b/offlineimap/repository/Base.py
@@ -146,6 +146,9 @@ class BaseRepository(CustomConfig.ConfigHelperMixin, object):
     def getfolder(self, foldername):
         raise NotImplementedError
 
+    def should_sync_folder(self, foldername):
+        return foldername in self.folderincludes or self.folderfilter(foldername)
+
     def sync_folder_structure(self, dst_repo, status_repo):
         """Syncs the folders in this repository to those in dest.
 
@@ -201,7 +204,7 @@ class BaseRepository(CustomConfig.ConfigHelperMixin, object):
                 # Does nametrans back&forth lead to identical names?
                 # 1) would src repo filter out the new folder name? In this
                 # case don't create it on it:
-                if not self.folderfilter(dst_name_t):
+                if not self.should_sync_folder(dst_name_t):
                     self.ui.debug('', "Not creating folder '%s' (repository '%s"
                         "') as it would be filtered out on that repository." %
                                   (dst_name_t, self))

--- a/offlineimap/repository/IMAP.py
+++ b/offlineimap/repository/IMAP.py
@@ -287,11 +287,6 @@ class IMAPRepository(BaseRepository):
             foldername = imaputil.dequote(name)
             retval.append(self.getfoldertype()(self.imapserver, foldername,
                                                self))
-            # filter out the folder?
-            if not self.folderfilter(foldername):
-                self.ui.debug('imap', "Filtering out '%s'[%s] due to folderfilt"
-                              "er" % (foldername, self))
-                retval[-1].sync_this = False
         # Add all folderincludes
         if len(self.folderincludes):
             imapobj = self.imapserver.acquireconnection()

--- a/offlineimap/repository/Maildir.py
+++ b/offlineimap/repository/Maildir.py
@@ -181,11 +181,6 @@ class MaildirRepository(BaseRepository):
                                                            foldername,
                                                            self.getsep(),
                                                            self))
-                # filter out the folder?
-                if not self.folderfilter(foldername):
-                    self.debug("Filtering out '%s'[%s] due to folderfilt"
-                               "er" % (foldername, self))
-                    retval[-1].sync_this = False
 
             if self.getsep() == '/' and dirname != '':
                 # Recursively check sub-directories for folders too.


### PR DESCRIPTION
``` python
 Deleting 7 messages (64508,64545,64643:64644,64648:64650) in MappedIMAP[INBOX]
 ERROR: Syncing folder INBOX [acc: BoostPro]
  global name 'OfflineImapError' is not defined
 ERROR: ERROR in syncfolder for BoostPro folder INBOX: Traceback (most recent call last):
  File "/usr/local/stow/.virtualenvs/offlineimap-6.5.4/lib/python2.7/site-packages/offlineimap/accounts.py", line 438, in syncfolder
    remotefolder.syncmessagesto(localfolder, statusfolder)
  File "/usr/local/stow/.virtualenvs/offlineimap-6.5.4/lib/python2.7/site-packages/offlineimap/folder/Base.py", line 526, in syncmessagesto
    action(dstfolder, statusfolder)
  File "/usr/local/stow/.virtualenvs/offlineimap-6.5.4/lib/python2.7/site-packages/offlineimap/folder/Base.py", line 432, in syncmessagesto_delete
    folder.deletemessages(deletelist)
  File "/usr/local/stow/.virtualenvs/offlineimap-6.5.4/lib/python2.7/site-packages/offlineimap/folder/UIDMaps.py", line 293, in deletemessages
    self._mb.deletemessages(self._uidlist(self.r2l, uidlist))
  File "/usr/local/stow/.virtualenvs/offlineimap-6.5.4/lib/python2.7/site-packages/offlineimap/folder/UIDMaps.py", line 88, in _uidlist
    raise OfflineImapError("Could not find UID for msg '{0}' (f:'{1}'."
NameError: global name 'OfflineImapError' is not defined
```
